### PR TITLE
Enable admin appointment management

### DIFF
--- a/backend/controlers/appointmentController.js
+++ b/backend/controlers/appointmentController.js
@@ -77,7 +77,7 @@ const getAppointmentsById = async (req, res) => {
     }
 
     // Validar que el usuario que solicita sea el dueño de la cita
-    if (appointment.user.toString() !== req.user._id.toString()) {
+    if (!req.user.admin && appointment.user.toString() !== req.user._id.toString()) {
       return res.status(403).json({ msg: 'No tienes permiso para ver esta cita' });
     }
 
@@ -99,7 +99,7 @@ const getAppointmentsById = async (req, res) => {
       return res.status(404).json({ msg: 'Cita no encontrada' });
     }
     // Validar que el usuario que solicita sea el dueño de la cita
-    if (appointment.user.toString() !== req.user._id.toString()) {
+    if (!req.user.admin && appointment.user.toString() !== req.user._id.toString()) {
       return res.status(403).json({ msg: 'No tienes permiso para actualizar esta cita' });
     }
     // Verificación previa: buscar si ya existe una cita para la misma fecha y hora
@@ -138,7 +138,7 @@ const getAppointmentsById = async (req, res) => {
       return res.status(404).json({ msg: 'Cita no encontrada' });
     }
     // Validar que el usuario que solicita sea el dueño de la cita
-    if (appointment.user.toString() !== req.user._id.toString()) {
+    if (!req.user.admin && appointment.user.toString() !== req.user._id.toString()) {
       return res.status(403).json({ msg: 'No tienes permiso para eliminar esta cita' });
     }
 

--- a/frontend/src/views/admin/AppointmentsView.vue
+++ b/frontend/src/views/admin/AppointmentsView.vue
@@ -1,9 +1,19 @@
 <script setup>
 import { useUserStore } from '@/stores/user'
 import Appointment from '@/components/Appointment.vue'
-import { onMounted } from 'vue'
+import { onMounted, ref, computed } from 'vue'
 
 const userStore = useUserStore()
+const search = ref('')
+
+const filteredAppointments = computed(() => {
+  if(!search.value) return userStore.userAppointments
+  return userStore.userAppointments.filter(a =>
+    a.user.name.toLowerCase().includes(search.value.toLowerCase()) ||
+    a.user.email.toLowerCase().includes(search.value.toLowerCase()) ||
+    new Date(a.date).toLocaleDateString().includes(search.value)
+  )
+})
 
 onMounted(async () => {
   // Fetch all appointments for admin
@@ -13,8 +23,14 @@ onMounted(async () => {
 
 <template>
   <div class="space-y-8">
-    <div class="flex justify-between items-center">
+    <div class="flex justify-between items-center gap-4">
       <p class="text-white">Total de citas: {{ userStore.userAppointments.length }}</p>
+      <input
+        v-model="search"
+        type="text"
+        placeholder="Buscar"
+        class="bg-gray-700 text-white px-3 py-1 rounded focus:outline-none"
+      />
     </div>
 
     <div class="bg-gray-800 rounded-lg p-6">
@@ -25,7 +41,7 @@ onMounted(async () => {
         </p>
         
         <div v-else class="space-y-6">
-          <div v-for="appointment in userStore.userAppointments" 
+          <div v-for="appointment in filteredAppointments"
                :key="appointment._id"
                class="bg-gray-900 rounded-lg p-4 mb-4">
             <!-- User info section -->


### PR DESCRIPTION
## Summary
- allow admins to edit and delete any appointment in backend
- add search functionality to admin appointments view

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841efa4bd8483308a634aaf47c731d3