### PR TITLE
Update token on login/logout and cleanup

### DIFF
--- a/backend/controlers/appointmentController.js
+++ b/backend/controlers/appointmentController.js
@@ -33,7 +33,6 @@ const createAppointment = async (req, res) => {
     return res.status(201).json({ msg: 'Cita creada exitosamente' });
     
   } catch (error) {
-    console.error('Error creating appointment:', error);
     return res.status(500).json({ msg: 'Error creating appointment' });
   }
 };
@@ -43,7 +42,6 @@ const createAppointment = async (req, res) => {
     const appointments = await Appointment.find();
     res.status(200).json(appointments);
   } catch (error) {
-    console.error('Error fetching appointments:', error);
     res.status(500).json({ msg: 'Error fetching appointments' });
   }
 };
@@ -84,7 +82,6 @@ const getAppointmentsById = async (req, res) => {
     res.status(200).json(appointment);
   }
   catch (error) {
-    console.error('Error fetching appointment:', error);
     res.status(500).json({ msg: 'Error fetching appointment' });
   }
 }
@@ -125,7 +122,6 @@ const getAppointmentsById = async (req, res) => {
     // Responder con éxito
     res.status(200).json({ msg: 'Cita actualizada exitosamente' });
   } catch (error) {
-    console.error('Error updating appointment:', error);
     res.status(500).json({ msg: 'Error updating appointment' });
   }
 };
@@ -149,7 +145,6 @@ const deleteAppointment = async (req, res) => {
 
     res.status(200).json({ msg: 'Cita eliminada exitosamente' });
   } catch (error) {
-    console.error('Error deleting appointment:', error);
     res.status(500).json({ msg: 'Error deleting appointment' });
   }
 };
@@ -189,7 +184,6 @@ const searchAppointments = async (req, res) => {
 
     res.status(200).json(appointments);
   } catch (error) {
-    console.error('Error searching appointments:', error);
     res.status(500).json({ msg: 'Error searching appointments' });
   }
 };

--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -4,6 +4,7 @@ import AuthApi from '@/api/AuthApi';
 import AppointmentAPI from '@/api/AppointmentAPI';
 import { useRouter } from 'vue-router';
 import router from '@/router';
+import api from '@/lib/axios'
 
 export const useUserStore = defineStore('user', () => {
 
@@ -40,9 +41,11 @@ export const useUserStore = defineStore('user', () => {
 
     const logout = async () => {
        localStorage.removeItem('AUTH_TOKEN');
-       user .value = {};
+       delete api.defaults.headers.common['Authorization'];
+       user.value = {};
+       userAppointments.value = [];
        router.push({name: 'login'});
-       
+
     }
 
      const noAppointments = computed(() => {

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -4,8 +4,11 @@ import InputField from '@/components/InputField.vue'
 import AuthApi from '@/api/AuthApi'
 import { inject } from 'vue'
 import { useRouter } from 'vue-router'
+import api from '@/lib/axios'
+import { useUserStore } from '@/stores/user'
 
 const router = useRouter()
+const userStore = useUserStore()
 
 const toast = inject('toast')
 
@@ -17,17 +20,15 @@ const initialValues = {
 async function onSubmit(values) {
   try {
     const { data } = await AuthApi.login(values)
+    // Store token and update axios authorization header
+    localStorage.setItem('AUTH_TOKEN', data.token)
+    api.defaults.headers.common['Authorization'] = `Bearer ${data.token}`
 
-
-    // Extrae y almacena el token en localStorage si está presente
-   
-      localStorage.setItem('AUTH_TOKEN', data.token)
-
-      router.push({ name: 'mis-reservaciones' })
-   
-
+    // Fetch authenticated user and store it
     const { data: user } = await AuthApi.auth()
-    
+    userStore.user = user
+    await userStore.getUserAppointments()
+
     if (user.admin) {
       router.push({ name: 'appointments-admin' })
     } else {


### PR DESCRIPTION
## Summary
- update axios authorization header when logging in
- clear the header and appointments on logout
- remove console debug messages from appointment controller
- store the authenticated user so their name appears in the layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68437da3d7188330bf8c574acd7b95d6